### PR TITLE
moved player name positions and added an extra row

### DIFF
--- a/src/playerslabel.js
+++ b/src/playerslabel.js
@@ -2,7 +2,7 @@ export class PlayersLabel extends Phaser.GameObjects.Container {
     constructor(scene, x, y, playersList) {
         super(scene, x, y);
         this.scene = scene;
-        this.heading = scene.add.text(20, 20, 'Players: ', { color: 'white' });
+        this.heading = scene.add.text(20, -10, 'Players: ', { color: 'white' });
         this.add(this.heading);
         this.playerLabels = [];
         this.updateWithPlayers(playersList);
@@ -30,7 +30,9 @@ export class PlayersLabel extends Phaser.GameObjects.Container {
             if (player.isDead) {
                 c = '#888888';
             }
-            let t = this.scene.add.text(100*i, 40, playerName, { 'color': c })
+            let x_coord = 100*(i % 7)
+            let y_coord = 20 + Math.floor(i/7)*30
+            let t = this.scene.add.text(x_coord, y_coord, playerName, { 'color': c })
             this.add(t);
             this.playerLabels.push(t);
             i++;


### PR DESCRIPTION
I moved the position of the word 'Players': up a little and it can now display up to 14 players (after every 7 players, it shifts down a row to add the new players)
