### PR TITLE
Show dice in same order for every player

### DIFF
--- a/src/scenes/dice-scene.js
+++ b/src/scenes/dice-scene.js
@@ -228,6 +228,8 @@ export class DiceScene extends Phaser.Scene {
     updateDice(action) {
         // we've taken an action that changes dice,
         // no mames is disabled
+        this.cup.reorder();
+        this.table.reorder();
         this.lookedButton.setEnabled(this.cup.getVisible());
         this.rolledButton.setEnabled(this.cup.didRoll());
         this.noMamesButton.setEnabled(false);
@@ -293,6 +295,15 @@ export class DiceScene extends Phaser.Scene {
                 break;
             }
             case Action.MOVE_ONE: {
+                //remove all dice
+                this.cup.getDice().forEach(d => {
+                    this.cup.remove(d);
+                });
+                this.table.getDice().forEach(d => {
+                    this.table.remove(d);
+                });
+
+                //refill all dice per message
                 let i = 0;
                 msg.cup.dice.forEach(die => {
                     this.dice[i].setValue(die);


### PR DESCRIPTION
by removing and replaying dice in both the cup and the table the issue is solved, as it was having issues with effectively dealing with six dice in play at any given time before sorting itself out. I also added the .reorder() functions to the beginning of the updateDice function to keep things tidy and looking proper.